### PR TITLE
Use the first file name as the project name

### DIFF
--- a/core/projects/endpoints.go
+++ b/core/projects/endpoints.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/eduardooliveira/stLib/core/discovery"
 	"github.com/eduardooliveira/stLib/core/models"
@@ -138,6 +139,8 @@ func new(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
+	projectName := uuid
+
 	for _, file := range files {
 		// Source
 		src, err := file.Open()
@@ -161,6 +164,9 @@ func new(c echo.Context) error {
 			return c.NoContent(http.StatusInternalServerError)
 		}
 
+		if projectName == uuid {
+			projectName = strings.TrimSuffix(file.Filename, filepath.Ext(file.Filename))
+		}
 	}
 	project := models.NewProjectFromPath(path)
 
@@ -169,6 +175,8 @@ func new(c echo.Context) error {
 		log.Printf("error loading the project %q: %v\n", path, err)
 		return err
 	}
+
+	project.Name = projectName
 
 	j, _ := json.Marshal(project)
 	log.Println(string(j))


### PR DESCRIPTION
When uploading 1 file (the normal use case for me) I expect the file name as the suggested project name.
On multiple files I would normally choose a project name anyway.

But couldn't really think when I would want to use the uuid as the name of the project.

This PR suggests the first file name as the project name.

The name update is done a bit late because currently the project path is calculated based on the name of the project so if we change it too early it fails.
There's an on-going question on this on discord so for now I'm ignoring that part.