### PR TITLE
Allow to upload all project info in one step

### DIFF
--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -79,7 +79,7 @@ func DiscoverProjectAssets(project *models.Project) error {
 	}
 
 	if !project.Initialized {
-		project.Tags = pathToTags(project.Path)
+		project.Tags = append(project.Tags, pathToTags(project.Path)...)
 	}
 
 	err = initProjectAssets(project, files)

--- a/core/projects/endpoints.go
+++ b/core/projects/endpoints.go
@@ -197,6 +197,12 @@ func new(c echo.Context) error {
 
 	state.Projects[project.UUID] = project
 
+	err = state.PersistProject(project)
+	if err != nil {
+		log.Println(err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
 	return c.JSON(http.StatusOK, struct {
 		UUID string `json:"uuid"`
 	}{project.UUID})

--- a/core/projects/endpoints.go
+++ b/core/projects/endpoints.go
@@ -14,7 +14,6 @@ import (
 	"github.com/eduardooliveira/stLib/core/runtime"
 	"github.com/eduardooliveira/stLib/core/state"
 	"github.com/eduardooliveira/stLib/core/utils"
-	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 )
 
@@ -114,6 +113,12 @@ func save(c echo.Context) error {
 	return c.JSON(http.StatusOK, pproject)
 }
 
+type CreateProject struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags"`
+}
+
 func new(c echo.Context) error {
 
 	form, err := c.MultipartForm()
@@ -129,10 +134,26 @@ func new(c echo.Context) error {
 		return c.NoContent(http.StatusBadRequest)
 	}
 
-	uuid := uuid.New().String()
+	projectPayload := form.Value["payload"]
+	if len(projectPayload) != 1 {
+		fmt.Println("more payloads than expected")
+		return c.NoContent(http.StatusBadRequest)
+	}
 
-	path := fmt.Sprintf("%s/%s", runtime.Cfg.LibraryPath, uuid)
+	createProject := &CreateProject{}
+	err = json.Unmarshal([]byte(projectPayload[0]), createProject)
+	if err != nil {
+		fmt.Println(err)
+		return c.NoContent(http.StatusBadRequest)
+	}
 
+	project := models.NewProject()
+	project.Name = createProject.Name
+	project.Path = "/"
+	project.Description = createProject.Description
+	project.Tags = createProject.Tags
+
+	path := fmt.Sprintf("%s%s", runtime.Cfg.LibraryPath, project.FullPath())
 	if err := os.Mkdir(path, os.ModePerm); err != nil {
 		log.Println(err)
 		return c.NoContent(http.StatusInternalServerError)
@@ -162,7 +183,6 @@ func new(c echo.Context) error {
 		}
 
 	}
-	project := models.NewProjectFromPath(path)
 
 	err = discovery.DiscoverProjectAssets(project)
 	if err != nil {


### PR DESCRIPTION
This PR refactors a bit of the endpoint creation to allow creating all the project info in just one step.

This allows the UI to be simpler but also simplifies the creation process.

In the past, it was possible to upload files and then abort the process and the files would be kept there.
There were also some moving files around since the project folder was created with the UUID and later on moved into the project name.

This refactor also allows us to create the folder with the final name and avoid moving around files.
And I think makes the code a bit easier to follow.


There's some cleanup to do on folder renaming for now I avoided touching too much in one PR.