### PR TITLE
Allow to run dockerfile without needing to mount or create folders

### DIFF
--- a/helpers/Dockerfile
+++ b/helpers/Dockerfile
@@ -16,8 +16,9 @@ WORKDIR /app
 COPY --from=go /app/main ./
 COPY --from=go /app/helpers/config.toml /config
 
-RUN mkdir /library
+RUN mkdir /app/library
 RUN mkdir /app/cache
+RUN mkdir /app/temp
 RUN ls -la /config
 RUN pwd
 RUN chmod +x main


### PR DESCRIPTION
Create some folders that the system expect to exists.

In a dev build noticed I needed to do 

```
    entrypoint: "bash"
    command: "-c 'mkdir /app/temp && mkdir /app/library && /app/main'"
```

To make it work if I was not going to mount any volume into it.