### PR TITLE
fix: Fix logPath handling

### DIFF
--- a/core/runtime/config.go
+++ b/core/runtime/config.go
@@ -37,6 +37,7 @@ func init() {
 	viper.AddConfigPath("/config")
 	viper.SetConfigType("toml")
 	viper.AutomaticEnv()
+	viper.AllowEmptyEnv(true)
 
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/core/stlib.go
+++ b/core/stlib.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path"
 
 	"github.com/eduardooliveira/stLib/core/assets"
 	"github.com/eduardooliveira/stLib/core/data/database"
@@ -25,7 +26,10 @@ import (
 func Run() {
 
 	if logPath := runtime.Cfg.LogPath; logPath != "" {
-		f, err := os.OpenFile("stlib.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		if _, err := os.Stat(logPath); os.IsNotExist(err) {
+			log.Fatalf("log_path %s does not exist", logPath)
+		}
+		f, err := os.OpenFile(path.Join(logPath, "stlib.log"), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 		if err != nil {
 			log.Fatalf("error opening file: %v", err)
 		}


### PR DESCRIPTION
Currently, it's not possible to set an empty value for the LOG_PATH environment variable because the related Viper config setting is missing.
Additionally, the `stlib.log` file isn't actually being written to `logPath`.

This PR fixes both, making it easier to run the container image with restricted permissions.